### PR TITLE
Update lodash to latest 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@captemulation/get-parameter-names": "^1.0.0",
-    "lodash": "^4.13.1"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",


### PR DESCRIPTION
lodash 4.17.10 and lower suffer from some kind of prototype pollution that has been fixed in 4.17.11

this is the changelog from 4.13.1 to 4.17.11

v4.17.11
Sep. 12, 2018 — Diff — Docs
Ensured _.merge handles function properties consistently regardless of number of sources
Ensured Object.prototype is not augmented by _.merge
Ensured placeholder properties are set on fp.convert() results
Avoided ReDoS issue in _.words implementation
v4.17.10
Apr. 24, 2018 — Diff — Docs
Updated Lodash for better Node.js 10 support
v4.17.5
Feb. 3, 2018 — Diff — Docs
Ensured _.clone supports subclassed arrays
Ensured _.cloneDeep works with cyclical maps & sets
Ensured _.defaults avoids unnecessary source property access
Ensured _.invert doesn’t error on inverted values without toString methods
Ensured _.merge & _.mergeWith avoid augmenting __proto__ properties
Ensured _.set supports paths with symbols
Ensured _.words detects ordinals in compound words
Ensured fp.update works with paths that refer to functions
v4.17.4
Dec. 31, 2016 — Diff — Docs
Ensured _.omit with deep paths doesn’t mutate object
v4.17.3
Dec. 24, 2016 — Diff — Docs
Added support for symbol properties to _.isEqual
Ensured getSymbols helper only gets enumerable symbols
Ensured _.startsWith avoids coercing position of undefined
Flipped iteratee arguments for fp.reduceRight
Removed the array length limit for lazy evaluation
v4.17.2
Nov. 15, 2016 — Diff — Docs
Ensured _.pick picks keys over paths
Ensured _.spread doesn’t include arguments after those spread
Fixed _.omit performance regression
v4.17.1
Nov. 14, 2016 — Diff — Docs
Ensured _.omit copies shallow path values by reference
Ensured _.pick supports path arrays
Ensured _.pickBy doesn’t treat keys with dots or brackets as deep paths
v4.17.0
Nov. 13, 2016 — Diff — Docs
Added deep path support to _.omit & _.pick
Ensured fp.assignAllWith & fp.mergeAllWith accept more than two sources
Made process.binding detection more cautious to avoid chatty debugging
v4.16.6
Oct. 31, 2016 — Diff — Docs
Ensured _.xor returns an empty array when comparing the same array
v4.16.5
Oct. 30, 2016 — Diff — Docs
Added support for ordinal numbers to _.words
Ensured _.xor works with more than two arrays
Ensuredfp.convert handles aliased & remapped methods
Improved “fp” debugging
Made “isType” methods resistant to toStringTag spoofing
Made _.isEmpty exit early for nullish values
Refined _.isError checks to avoid false positives for plain objects
Simplified _.isElement
v4.16.4
Oct. 6, 2016 — Diff — Docs
Added support for buffers to _.transform
Added support for typed arrays to _.isEmpty
Ensured _.toString works on an array of symbols
Fixed _.merge regression with buffers
Normalized buffers & typed arrays keys in “keys” methods
Split _.isArguments out for older & newer environments
v4.16.3
Oct. 3, 2016 — Diff — Docs
Added a _.runInContext check in the “fp” browser build
Ensured _.defaultsDeep & _.merge consistently assign undefined values
Fixed _.isFunction detection of Proxy in Safari 10
Made _.isEqual treat buffers differently than Uint8Array values
Removed es-sham requirement for older browsers
v4.16.2
Sept. 25, 2016 — Diff — Docs
Fixed _.sampleSize performance regression
Made “clone” methods use newer Buffer APIs when available
v4.16.1
Sept. 20, 2016 — Diff — Docs
Fixed backtick removal of _.escape & _.unescape
Improved parse time by 2x in V8
v4.16.0
Sept. 19, 2016 — Diff — Docs
Added fp.rangeStep & fp.rangeStepRight
Added a cache limit to internal _.memoize use
Avoided V8 de-opts in _.isElement, _.isObject, & _.isObjectLike
Dropped backtick encoding from _.escape & _.unescape
Dropped testing in Node.js 0.10 & 0.12
Ensured __proto__ is treated as a regular key in assignments
Fixed _.bind & _.partial performance regression
Optimized _.concat
v4.15.0
Aug. 12, 2016 — Diff — Docs
Added Latin Extended-A block support to _.deburr
Reduced dependencies of _.isEmpty & _.toNumber
v4.14.2
Aug. 8, 2016 — Diff — Docs
Ensured methods work with mocked Date.now, clearTimeout, & setTimeout
Ensured paths of “set” methods overwrite primitives
Ensured fp.nthArg returns a curried function
Reduced dependencies of _.initial, _.merge, & _.tail
Removed old JIT & engine bug guards
v4.14.1
July 29, 2016 — Diff — Docs
Ensured paths with consecutive empty brackets or dots are parsed correctly
Ensured _.random & “range” methods coerce arguments to finite numbers
Fixed circular reference detection in _.cloneDeep
Removed global prerequisite for exports detection
v4.14.0
July 24, 2016 — Diff — Docs
Added _.conformsTo & _.defaultTo
Added more “fp” aliases
Added “All” variants of fp/assign, fp/defaults,fp/merge, & fp/zip methods
Ensured debounced cancel uses clearTimeout
Ensured the alias _.first supports shortcut fusion
Ensured _.assignWith respects customizer results of undefined
Ensured _.divide & _.multiply return 1 when no arguments are specified
Ensured _.isEqual has transitive equivalence for circular references
Fixed argument order of fp/zipObjectDeep
Simplified resolving the global object
Stopped unconditional global exports in the browser
Made per method packages zero-dependency modules
Made wrapped function toString results more debuggable
Made “flatten” methods honor Symbol.isConcatSpreadable
Made _.isEqual treat invalid dates as equivalent
Made LARGE_ARRAY_SIZE check in stackSet align with others
Optimized adding values to stacks by not inspecting all key-value pairs
Optimized “isType” methods to use faster Node.js C++ helpers when available
Optimized _.endsWith, _.negate, & _.startsWith
